### PR TITLE
PrairieViewReader updated for fixed Zaxis scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.4.2] - 2022-12-16
++ Update - PrairieView loader checks for multi-plane vs single-plane scans.
+
 ## [0.4.1] - 2022-12-15
 
 + Update - PrairieView loader now reads recording start time from metadata file
@@ -41,6 +44,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 
 + Add - Readers for: `ScanImage`, `Suite2p`, `CaImAn`.
 
+[0.4.2]: https://github.com/datajoint/element-interface/releases/tag/0.4.2
 [0.4.1]: https://github.com/datajoint/element-interface/releases/tag/0.4.1
 [0.4.0]: https://github.com/datajoint/element-interface/releases/tag/0.4.0
 [0.3.0]: https://github.com/datajoint/element-interface/releases/tag/0.3.0

--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -40,6 +40,16 @@ run deconvolution using the `spikedetect` flag (
 `segmentation_suite2p` functions is only a subset of the keys generated with the
 `suite2p.default_ops()` function.
 
+### PrairieView Reader
+
+This Element provides a function to read the PrairieView Scanner's metadata
+file. The PrairieView software generates one `.ome.tif` imaging file per frame acquired. The
+metadata for all frames is contained in one `.xml` file. This function locates the `.xml`
+file and generates a dictionary necessary to populate the DataJoint ScanInfo and
+Field tables. PrairieView works with resonance scanners with a single field,
+does not support bidirectional x and y scanning, and the `.xml` file does not
+contain ROI information.
+
 ## Element Architecture
 
 The functions for each acquisition and analysis package are stored within a separate

--- a/element_interface/prairieviewreader.py
+++ b/element_interface/prairieviewreader.py
@@ -41,10 +41,10 @@ def get_pv_metadata(pvtiffile: str) -> dict:
         )
 
     bidirectional_scan = False  # Does not support bidirectional
-
+    roi = 1
     n_fields = 1  # Always contains 1 field
-
-    record_start_time = root.findall(".//Sequence/[@cycle='1']").attrib.get("time")
+    record_start_time = root.find(
+        ".//Sequence/[@cycle='1']").attrib.get("time")
 
     # Get all channels and find unique values
     channel_list = [
@@ -52,31 +52,10 @@ def get_pv_metadata(pvtiffile: str) -> dict:
         for channel in root.iterfind(".//Sequence/Frame/File/[@channel]")
     ]
     n_channels = len(set(channel_list))
-
-    # One "Frame" per depth. Gets number of frames in first sequence
-    planes = [
-        int(plane.attrib.get("index"))
-        for plane in root.findall(".//Sequence/[@cycle='1']/Frame")
-    ]
-    n_depths = len(set(planes))
-
     n_frames = len(root.findall(".//Sequence/Frame"))
-
-    roi = 1
-    # x and y coordinate values for the center of the field
-    x_field = float(
-        root.find(
-            ".//PVStateValue/[@key='currentScanCenter']/IndexedValue/[@index='XAxis']"
-        ).attrib.get("value")
-    )
-    y_field = float(
-        root.find(
-            ".//PVStateValue/[@key='currentScanCenter']/IndexedValue/[@index='YAxis']"
-        ).attrib.get("value")
-    )
-
     framerate = 1 / float(
-        root.findall('.//PVStateValue/[@key="framePeriod"]')[0].attrib.get("value")
+        root.findall(
+            './/PVStateValue/[@key="framePeriod"]')[0].attrib.get("value")
     )  # rate = 1/framePeriod
 
     usec_per_line = (
@@ -88,16 +67,16 @@ def get_pv_metadata(pvtiffile: str) -> dict:
         * 1e6
     )  # Convert from seconds to microseconds
 
-    scan_datetime = datetime.strptime(root.attrib.get("date"), "%m/%d/%Y %I:%M:%S %p")
+    scan_datetime = datetime.strptime(
+        root.attrib.get("date"), "%m/%d/%Y %I:%M:%S %p")
 
     total_duration = float(
         root.findall(".//Sequence/Frame")[-1].attrib.get("relativeTime")
     )
 
-    bidirection_z = bool(root.find(".//Sequence").attrib.get("bidirectionalZ"))
-
     px_height = int(
-        root.findall(".//PVStateValue/[@key='pixelsPerLine']")[0].attrib.get("value")
+        root.findall(
+            ".//PVStateValue/[@key='pixelsPerLine']")[0].attrib.get("value")
     )
     # All PrairieView-acquired images have square dimensions (512 x 512; 1024 x 1024)
     px_width = px_height
@@ -110,23 +89,57 @@ def get_pv_metadata(pvtiffile: str) -> dict:
 
     um_height = um_width = float(px_height) * um_per_pixel
 
-    z_min = float(
-        root.findall(
-            ".//Sequence/[@cycle='1']/Frame/PVStateShard/PVStateValue/[@key='positionCurrent']/SubindexedValues/SubindexedValue/[@subindex='0']"
-        )[0].attrib.get("value")
-    )
-    z_max = float(
-        root.findall(
-            ".//Sequence/[@cycle='1']/Frame/PVStateShard/PVStateValue/[@key='positionCurrent']/SubindexedValues/SubindexedValue/[@subindex='0']"
-        )[-1].attrib.get("value")
-    )
-    z_step = float(
+    # x and y coordinate values for the center of the field
+    x_field = float(
         root.find(
-            ".//PVStateShard/PVStateValue/[@key='micronsPerPixel']/IndexedValue/[@index='ZAxis']"
+            ".//PVStateValue/[@key='currentScanCenter']/IndexedValue/[@index='XAxis']"
         ).attrib.get("value")
     )
-    z_fields = np.arange(z_min, z_max + 1, z_step)
-    assert z_fields.size == n_depths
+    y_field = float(
+        root.find(
+            ".//PVStateValue/[@key='currentScanCenter']/IndexedValue/[@index='YAxis']"
+        ).attrib.get("value")
+    )
+
+    if root.find(".//Sequence/[@cycle='1']/Frame/PVStateShard/PVStateValue/[@key='positionCurrent']/SubindexedValues/[@index='ZAxis']") is None:
+
+        z_fields = np.float64(
+            root.find(
+                ".//PVStateValue/[@key='positionCurrent']/SubindexedValues/[@index='ZAxis']/SubindexedValue").attrib.get("value")
+        )
+        n_depths = 1
+        assert z_fields.size == n_depths
+        bidirection_z = False
+        
+    else:
+
+        bidirection_z = bool(
+            root.find(".//Sequence").attrib.get("bidirectionalZ"))
+
+        # One "Frame" per depth. Gets number of frames in first sequence
+        planes = [
+            int(plane.attrib.get("index"))
+            for plane in root.findall(".//Sequence/[@cycle='1']/Frame")
+        ]
+        n_depths = len(set(planes))
+
+        z_min = float(
+            root.findall(
+                ".//Sequence/[@cycle='1']/Frame/PVStateShard/PVStateValue/[@key='positionCurrent']/SubindexedValues/SubindexedValue/[@subindex='0']"
+            )[0].attrib.get("value")
+        )
+        z_max = float(
+            root.findall(
+                ".//Sequence/[@cycle='1']/Frame/PVStateShard/PVStateValue/[@key='positionCurrent']/SubindexedValues/SubindexedValue/[@subindex='0']"
+            )[-1].attrib.get("value")
+        )
+        z_step = float(
+            root.find(
+                ".//PVStateShard/PVStateValue/[@key='micronsPerPixel']/IndexedValue/[@index='ZAxis']"
+            ).attrib.get("value")
+        )
+        z_fields = np.arange(z_min, z_max + 1, z_step)
+        assert z_fields.size == n_depths
 
     metainfo = dict(
         num_fields=n_fields,
@@ -150,7 +163,7 @@ def get_pv_metadata(pvtiffile: str) -> dict:
         fieldX=x_field,
         fieldY=y_field,
         fieldZ=z_fields,
-        recording_time = record_start_time,
+        recording_time=record_start_time,
     )
 
     return metainfo

--- a/element_interface/prairieviewreader.py
+++ b/element_interface/prairieviewreader.py
@@ -100,7 +100,6 @@ def get_pv_metadata(pvtiffile: str) -> dict:
             ".//PVStateValue/[@key='currentScanCenter']/IndexedValue/[@index='YAxis']"
         ).attrib.get("value")
     )
-
     if root.find(".//Sequence/[@cycle='1']/Frame/PVStateShard/PVStateValue/[@key='positionCurrent']/SubindexedValues/[@index='ZAxis']") is None:
 
         z_fields = np.float64(
@@ -110,7 +109,7 @@ def get_pv_metadata(pvtiffile: str) -> dict:
         n_depths = 1
         assert z_fields.size == n_depths
         bidirection_z = False
-        
+
     else:
 
         bidirection_z = bool(
@@ -122,7 +121,6 @@ def get_pv_metadata(pvtiffile: str) -> dict:
             for plane in root.findall(".//Sequence/[@cycle='1']/Frame")
         ]
         n_depths = len(set(planes))
-
         z_min = float(
             root.findall(
                 ".//Sequence/[@cycle='1']/Frame/PVStateShard/PVStateValue/[@key='positionCurrent']/SubindexedValues/SubindexedValue/[@subindex='0']"

--- a/element_interface/version.py
+++ b/element_interface/version.py
@@ -1,3 +1,3 @@
 """Package metadata"""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"


### PR DESCRIPTION
In this PR, the PrairieView reader can check for whether a scan was acquired from multiple planes along the Z-axis or a single plane. The current version assumes this scanner captures multiple planes in the z-axis by default. 

In this PR, thanks to the `settings.xml` file provided by the Sippy Lab, I incorporated an `if-else` statement to check whether the z-axis is fixed and update certain parameters accordingly. 

Two of our workflows/labs will now be able to use the same loader for their data.