### PR TITLE
Fix DANDI Upload URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.5.4] - 2023-05-14
+
++ Fix - DANDI URL for uploads where `staging=False`.
+
 ## [0.5.3] - 2023-05-11
 
 + Fix - `.ipynb` dark mode output for all notebooks.
@@ -66,6 +70,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 
 + Add - Readers for: `ScanImage`, `Suite2p`, `CaImAn`.
 
+[0.5.4]: https://github.com/datajoint/element-interface/releases/tag/0.5.4
 [0.5.3]: https://github.com/datajoint/element-interface/releases/tag/0.5.3
 [0.5.2]: https://github.com/datajoint/element-interface/releases/tag/0.5.2
 [0.5.1]: https://github.com/datajoint/element-interface/releases/tag/0.5.1

--- a/element_interface/dandi.py
+++ b/element_interface/dandi.py
@@ -39,7 +39,7 @@ def upload_to_dandi(
     download(
         f"https://gui-staging.dandiarchive.org/#/dandiset/{dandiset_id}"
         if staging
-        else dandiset_id,
+        else f"https://dandiarchive.org/dandiset/{dandiset_id}",
         output_dir=working_directory,
     )
 

--- a/element_interface/version.py
+++ b/element_interface/version.py
@@ -1,3 +1,3 @@
 """Package metadata"""
 
-__version__ = "0.5.3"
+__version__ = "0.5.4"


### PR DESCRIPTION
This PR fixes an error when `staging=False` in the dandi upload utility. The existing code resulted in a URL that is just the `dandiset_id` rather than the full URL, resulting in an error.

PR Summary:

- [x] Fix DANDI upload URL
- [x] Test the fix locally
- [x] Update CHANGELOG
- [x] Update version.py