### PR TITLE
Check for z_fields in 2nd cycle `.xml` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
 
+## [0.7.0] - 2023-09-05
+
++ Add - multi-plane `caiman_loader.py` to process multi-plane tiffs
++ Update - DANDI upload utility
+
 ## [0.6.1] - 2023-08-02
 
 + Update DANDI upload funtionality to improve useability
@@ -83,6 +88,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 
 + Add - Readers for: `ScanImage`, `Suite2p`, `CaImAn`.
 
+[0.7.0]: https://github.com/datajoint/element-interface/releases/tag/0.7.0
 [0.6.0]: https://github.com/datajoint/element-interface/releases/tag/0.6.0
 [0.5.4]: https://github.com/datajoint/element-interface/releases/tag/0.5.4
 [0.5.3]: https://github.com/datajoint/element-interface/releases/tag/0.5.3

--- a/element_interface/caiman_loader.py
+++ b/element_interface/caiman_loader.py
@@ -296,6 +296,7 @@ class CaImAn:
                 pln_cm.motion_correction[img_type][...]
                 for pln_cm in self.planes.values()
             )
+            raise Exception("Debug summary images")
         return img_
 
     @property

--- a/element_interface/caiman_loader.py
+++ b/element_interface/caiman_loader.py
@@ -296,7 +296,6 @@ class CaImAn:
                 pln_cm.motion_correction[img_type][...]
                 for pln_cm in self.planes.values()
             )
-            raise Exception("Debug summary images")
         return img_
 
     @property

--- a/element_interface/prairie_view_loader.py
+++ b/element_interface/prairie_view_loader.py
@@ -205,7 +205,7 @@ def _extract_prairieview_metadata(xml_filepath: str):
 
     if (
         xml_root.find(
-            ".//Sequence/[@cycle='1']/Frame/PVStateShard/PVStateValue/[@key='positionCurrent']/SubindexedValues/[@index='ZAxis']"
+            ".//Sequence/[@cycle='2']/Frame/PVStateShard/PVStateValue/[@key='positionCurrent']/SubindexedValues/[@index='ZAxis']"
         )
         is None
     ):
@@ -232,7 +232,7 @@ def _extract_prairieview_metadata(xml_filepath: str):
         n_depths = len(plane_indices)
 
         z_controllers = xml_root.findall(
-            ".//Sequence/[@cycle='1']/Frame/[@index='1']/PVStateShard/PVStateValue/[@key='positionCurrent']/SubindexedValues/[@index='ZAxis']/SubindexedValue"
+            ".//Sequence/[@cycle='2']/Frame/[@index='1']/PVStateShard/PVStateValue/[@key='positionCurrent']/SubindexedValues/[@index='ZAxis']/SubindexedValue"
         )
 
         # If more than one Z-axis controllers are found,
@@ -241,13 +241,13 @@ def _extract_prairieview_metadata(xml_filepath: str):
         if len(z_controllers) > 1:
             z_repeats = []
             for controller in xml_root.findall(
-                ".//Sequence/[@cycle='1']/Frame/[@index='1']/PVStateShard/PVStateValue/[@key='positionCurrent']/SubindexedValues/[@index='ZAxis']/"
+                ".//Sequence/[@cycle='2']/Frame/[@index='1']/PVStateShard/PVStateValue/[@key='positionCurrent']/SubindexedValues/[@index='ZAxis']/"
             ):
                 z_repeats.append(
                     [
                         float(z.attrib.get("value"))
                         for z in xml_root.findall(
-                            ".//Sequence/[@cycle='1']/Frame/PVStateShard/PVStateValue/[@key='positionCurrent']/SubindexedValues/[@index='ZAxis']/SubindexedValue/[@subindex='{0}']".format(
+                            ".//Sequence/[@cycle='2']/Frame/PVStateShard/PVStateValue/[@key='positionCurrent']/SubindexedValues/[@index='ZAxis']/SubindexedValue/[@subindex='{0}']".format(
                                 controller.attrib.get("subindex")
                             )
                         )
@@ -267,7 +267,7 @@ def _extract_prairieview_metadata(xml_filepath: str):
             z_fields = [
                 z.attrib.get("value")
                 for z in xml_root.findall(
-                    ".//Sequence/[@cycle='1']/Frame/PVStateShard/PVStateValue/[@key='positionCurrent']/SubindexedValues/[@index='ZAxis']/SubindexedValue/[@subindex='0']"
+                    ".//Sequence/[@cycle='2']/Frame/PVStateShard/PVStateValue/[@key='positionCurrent']/SubindexedValues/[@index='ZAxis']/SubindexedValue/[@subindex='0']"
                 )
             ]
 


### PR DESCRIPTION
Currently, the routine determines whether there are multiple z-planes and which z-controllers to use based on information about the 1st acquisition frame in the metadata `.xml` file. After comparing two different sessions, some `.xml` files do not record any z-axis information in the 1st acquisition sequence. 

This PR updates the z-field routines in the `prairie_view_loader` to check for z-axis controller and field information in the 2nd sequence of acquisition.