### PR TITLE
Fix file name extraction from PrairieView metadata

### DIFF
--- a/element_interface/prairie_view_loader.py
+++ b/element_interface/prairie_view_loader.py
@@ -75,7 +75,7 @@ class PrairieViewMeta:
             ), f"Invalid 'channel' - Channels: {self.meta['channels']}"
 
         frames = self._xml_root.findall(
-            f".//Sequence/Frame/[@index='{plane_idx}']/File/[@channel='{channel}']"
+            f".//Sequence/Frame/File/[@channel='{channel}']"
         )
 
         fnames = [f.attrib["filename"] for f in frames]


### PR DESCRIPTION
The old version would look for all values that matched frame number 1 which would return only 1 `.ome.tif` file name for creating the big tiff. This updated version returns all file names that follow the `Sequence/Frame/File/channel` structure. 