### PR TITLE
Bugfix - remove hardcoded `n_fields` from `prairie_view_loader.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 
 + Add - multi-plane `caiman_loader.py` to process multi-plane tiffs
 + Update - DANDI upload utility
++ Fix - `n_fields` == 1 -> `n_fields` == `n_depths` in `prairie_view_loader.py`
 
 ## [0.6.1] - 2023-08-02
 

--- a/element_interface/prairie_view_loader.py
+++ b/element_interface/prairie_view_loader.py
@@ -155,7 +155,6 @@ def _extract_prairieview_metadata(xml_filepath: str):
 
     bidirectional_scan = False  # Does not support bidirectional
     roi = 0
-    n_fields = 1  # Always contains 1 field
     recording_start_time = xml_root.find(".//Sequence/[@cycle='1']").attrib.get("time")
 
     # Get all channels and find unique values
@@ -288,7 +287,7 @@ def _extract_prairieview_metadata(xml_filepath: str):
         ), "Number of z fields does not match number of depths."
 
     metainfo = dict(
-        num_fields=n_fields,
+        num_fields=n_depths,
         num_channels=n_channels,
         num_planes=n_depths,
         num_frames=n_frames,


### PR DESCRIPTION
Since there is no confirmation that PrairieView supports mesoscope scanning, the number of fields acquired using the Bruker software should be equal of the number of depths acquired during a scan. This PR removes the previously hardcoded `n_fields = 1` from the loader utility and instead sets the value to the number of depths so that `n_fields = n_depths`. 