### PR TITLE
Add codespell: workflow + config and have it fix some typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git,*.svg,*.css,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,6 @@
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git,*.svg,*.css,.codespellrc
+skip = .git,*.svg,*.css,.codespellrc,cspell.json
 check-hidden = true
 # ignore-regex = 
 # ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,3 +54,10 @@ repos:
           # W605 - a backslash-character pair that is not a valid escape sequence now
           #        generates a DeprecationWarning. This will eventually become a SyntaxError.
           #        Needed because we use \d as an escape sequence
+
+  # codespell
+  - repo: https://github.com/codespell-project/codespell
+    # Configuration for codespell is in .codespellrc
+    rev: v2.2.6
+    hooks:
+    - id: codespell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 
 ## [0.6.1] - 2023-08-02
 
-+ Update DANDI upload funtionality to improve useability
++ Update DANDI upload functionality to improve usability
 
 
 ## [0.6.0] - 2023-07-26

--- a/element_interface/caiman_loader.py
+++ b/element_interface/caiman_loader.py
@@ -79,7 +79,7 @@ class CaImAn:
         else:
             raise FileNotFoundError(
                 "No CaImAn analysis output file found at {}"
-                " containg all required fields ({})".format(
+                " containing all required fields ({})".format(
                     caiman_dir, _required_hdf5_fields
                 )
             )

--- a/element_interface/extract_trigger.py
+++ b/element_interface/extract_trigger.py
@@ -11,7 +11,7 @@ class EXTRACT_trigger:
         data = load('{scanfile}');
         M = data.M;
 
-        % Input Paramaters
+        % Input Parameters
         config = struct();
         {parameters_list_string}
 
@@ -31,7 +31,7 @@ class EXTRACT_trigger:
 
         Args:
             scanfile (Union[str, Path]): Full path of the scan
-            parameters (dict): EXTRACT input paramaters.
+            parameters (dict): EXTRACT input parameters.
             output_dir (Union[str, Path]): Directory to store the outputs of EXTRACT analysis.
         """
         assert isinstance(parameters, dict)

--- a/element_interface/suite2p_loader.py
+++ b/element_interface/suite2p_loader.py
@@ -64,7 +64,7 @@ class Suite2p:
 
         self.creation_time = min(
             [p.creation_time for p in self.planes.values()]
-        )  # ealiest file creation time
+        )  # earliest file creation time
         self.curation_time = max(
             [p.curation_time for p in self.planes.values()]
         )  # most recent curation time


### PR DESCRIPTION
cspell should be able to catch those too I think, but it might be having smaller dictionary of typos and/or not checking .py at all?

Feel free to just cherry pick last commit with the actual fixes