### PR TITLE
Update multiprocessing arguments to latest versions

### DIFF
--- a/element_interface/run_caiman.py
+++ b/element_interface/run_caiman.py
@@ -45,7 +45,7 @@ def run_caiman(
     opts = params.CNMFParams(params_dict=parameters)
 
     c, dview, n_processes = cm.cluster.setup_cluster(
-        backend="ipyparallel", n_processes=None, single_thread=False
+        backend="multiprocessing", n_processes=None, single_thread=False
     )
 
     try:

--- a/element_interface/run_caiman.py
+++ b/element_interface/run_caiman.py
@@ -45,7 +45,7 @@ def run_caiman(
     opts = params.CNMFParams(params_dict=parameters)
 
     c, dview, n_processes = cm.cluster.setup_cluster(
-        backend="local", n_processes=None, single_thread=True
+        backend="ipyparallel", n_processes=None, single_thread=False
     )
 
     try:

--- a/element_interface/run_caiman.py
+++ b/element_interface/run_caiman.py
@@ -45,7 +45,7 @@ def run_caiman(
     opts = params.CNMFParams(params_dict=parameters)
 
     c, dview, n_processes = cm.cluster.setup_cluster(
-        backend="multiprocessing", n_processes=None, single_thread=False
+        backend="multiprocessing", n_processes=None
     )
 
     try:


### PR DESCRIPTION
This updates `backend` argument to `multiprocessing` which removes the warning that `local` may be removed in the future. The `single_thread` argument is now deprecated. `backend` can be set to `single` if needed for debugging