### PR TITLE
Convert pathlib.Path objects to POSIX strings for file operations

### DIFF
--- a/element_interface/caiman_loader.py
+++ b/element_interface/caiman_loader.py
@@ -41,7 +41,7 @@ class CaImAn:
 
         caiman_subdirs = []
         for fp in caiman_dir.rglob("*.hdf5"):
-            with h5py.File(fp, "r") as h5f:
+            with h5py.File(fp.as_posix(), "r") as h5f:
                 if all(s in h5f for s in _required_hdf5_fields):
                     caiman_subdirs.append(fp.parent)
 
@@ -381,7 +381,7 @@ class _CaImAn:
             raise FileNotFoundError("CaImAn directory not found: {}".format(caiman_dir))
 
         for fp in caiman_dir.glob("*.hdf5"):
-            with h5py.File(fp, "r") as h5f:
+            with h5py.File(fp.as_posix(), "r") as h5f:
                 if all(s in h5f for s in _required_hdf5_fields):
                     self.caiman_fp = fp
                     break
@@ -394,17 +394,17 @@ class _CaImAn:
             )
 
         # ---- Initialize CaImAn's results ----
-        self.cnmf = cm.source_extraction.cnmf.cnmf.load_CNMF(self.caiman_fp)
+        self.cnmf = cm.source_extraction.cnmf.cnmf.load_CNMF(self.caiman_fp.as_posix())
         self.params = self.cnmf.params
 
-        self.h5f = h5py.File(self.caiman_fp, "r")
+        self.h5f = h5py.File(self.caiman_fp.as_posix(), "r")
         self.plane_idx = None if self.params.motion["is3D"] else 0
         self._motion_correction = None
         self._masks = None
 
         # ---- Metainfo ----
-        self.creation_time = datetime.fromtimestamp(os.stat(self.caiman_fp).st_ctime)
-        self.curation_time = datetime.fromtimestamp(os.stat(self.caiman_fp).st_ctime)
+        self.creation_time = datetime.fromtimestamp(os.stat(self.caiman_fp.as_posix()).st_ctime)
+        self.curation_time = datetime.fromtimestamp(os.stat(self.caiman_fp.as_posix()).st_ctime)
 
     @property
     def motion_correction(self):
@@ -589,7 +589,7 @@ def _save_mc(
 
     # Open hdf5 file and create 'motion_correction' group
     caiman_fp = pathlib.Path(caiman_fp)
-    h5f = h5py.File(caiman_fp, "r+" if caiman_fp.exists() else "w")
+    h5f = h5py.File(caiman_fp.as_posix(), "r+" if caiman_fp.exists() else "w")
     h5g = h5f.require_group("motion_correction")
 
     # Write motion correction shifts and motion corrected summary images to hdf5 file

--- a/element_interface/dandi.py
+++ b/element_interface/dandi.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import subprocess
 
 from dandi.upload import upload
@@ -31,14 +32,14 @@ def upload_to_dandi(
         validation (str, optional): [require|skip|ignore] see full description from `dandi upload --help`
     """
 
-    working_directory = working_directory or os.path.curdir
+    working_directory = working_directory or "."
 
     if api_key is not None:
         os.environ["DANDI_API_KEY"] = api_key
 
-    dandiset_directory = os.path.join(
-        working_directory, str(dandiset_id)
-    )  # enforce str
+    dandiset_directory = (
+        pathlib.Path(working_directory) / str(dandiset_id)
+    ).as_posix()
 
     dandiset_url = (
         f"https://gui-staging.dandiarchive.org/#/dandiset/{dandiset_id}"

--- a/element_interface/prairie_view_loader.py
+++ b/element_interface/prairie_view_loader.py
@@ -152,7 +152,7 @@ class PrairieViewMeta:
                     self.meta["height_in_pixels"],
                     self.meta["width_in_pixels"],
                 ],
-                dtype=int,
+                dtype=np.uint16, # use unsigned int 16 instead of int. int is defined as 32 or 64 bit based on the platform -> this will inflated a 16 bit tiff by 2 to 4 times!
             )
             start_page = 0
             try:

--- a/element_interface/prairie_view_loader.py
+++ b/element_interface/prairie_view_loader.py
@@ -22,7 +22,7 @@ class PrairieViewMeta:
         self.prairieview_dir = Path(prairieview_dir)
 
         for file in self.prairieview_dir.glob("*.xml"):
-            xml_tree = ET.parse(file)
+            xml_tree = ET.parse(file.as_posix())
             xml_root = xml_tree.getroot()
             if xml_root.find(".//Sequence"):
                 self.xml_file = file
@@ -157,7 +157,7 @@ class PrairieViewMeta:
             start_page = 0
             try:
                 for input_file in tiff_names:
-                    with tifffile.TiffFile(self.prairieview_dir / input_file) as tffl:
+                    with tifffile.TiffFile((self.prairieview_dir / input_file).as_posix()) as tffl:
                         # Get indices in this tiff file and in output array
                         final_page_in_file = start_page + len(tffl.pages)
                         is_page_in_file = lambda page: page in range(
@@ -181,7 +181,7 @@ class PrairieViewMeta:
 
             output_tiff_fullpath = output_dir / f"{output_tiff_stem}.tif"
             tifffile.imwrite(
-                output_tiff_fullpath,
+                output_tiff_fullpath.as_posix(),
                 combined_data,
                 metadata={"axes": "TYX", "'fps'": self.meta["frame_rate"]},
                 bigtiff=True,
@@ -193,14 +193,14 @@ class PrairieViewMeta:
                     output_dir / f"{output_tiff_stem}_{len(output_tiff_list):04}.tif"
                 )
                 with tifffile.TiffWriter(
-                    output_tiff_fullpath,
+                    output_tiff_fullpath.as_posix(),
                     bigtiff=True,
                 ) as tiff_writer:
                     while len(tiff_names):
                         input_file = tiff_names.pop(0)
                         try:
                             with tifffile.TiffFile(
-                                self.prairieview_dir / input_file
+                                (self.prairieview_dir / input_file).as_posix()
                             ) as tffl:
                                 assert len(tffl.pages) == 1
                                 tiff_writer.write(
@@ -233,7 +233,7 @@ def _extract_prairieview_metadata(xml_filepath: str):
     xml_filepath = Path(xml_filepath)
     if not xml_filepath.exists():
         raise FileNotFoundError(f"{xml_filepath} does not exist")
-    xml_tree = ET.parse(xml_filepath)
+    xml_tree = ET.parse(xml_filepath.as_posix())
     xml_root = xml_tree.getroot()
 
     bidirectional_scan = False  # Does not support bidirectional
@@ -428,7 +428,7 @@ def get_prairieview_metadata(ome_tif_filepath: str) -> dict:
     xml_files_list = pathlib.Path(ome_tif_filepath).parent.glob("*.xml")
 
     for file in xml_files_list:
-        xml_tree = ET.parse(file)
+        xml_tree = ET.parse(file.as_posix())
         xml_file = xml_tree.getroot()
         if xml_file.find(".//Sequence"):
             break

--- a/element_interface/run_caiman.py
+++ b/element_interface/run_caiman.py
@@ -58,7 +58,7 @@ def run_caiman(
         parameters["motion"] = {**parameters.get("motion", {}), "indices": indices}
 
     caiman_temp = os.environ.get("CAIMAN_TEMP")
-    os.environ["CAIMAN_TEMP"] = str(output_dir)
+    os.environ["CAIMAN_TEMP"] = pathlib.Path(output_dir).as_posix()
 
     # use 80% of available cores
     if n_processes is None:

--- a/element_interface/suite2p_trigger.py
+++ b/element_interface/suite2p_trigger.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import warnings
 
 import numpy as np
@@ -206,9 +207,13 @@ def deconvolution_suite2p(segmentation_ops: dict, db: dict) -> np.ndarray:
         )
         segmentation_ops.update(do_registration=0, roidetect=False, spikedetect=True)
 
-    F = np.load(db["fast-disk"] + "/suite2p/" + "plane0" + "/F.npy", allow_pickle=True)
+    F = np.load(
+        (pathlib.Path(db["fast-disk"]) / "suite2p" / "plane0" / "F.npy").as_posix(),
+        allow_pickle=True,
+    )
     Fneu = np.load(
-        db["fast-disk"] + "/suite2p/" + "plane0" + "/Fneu.npy", allow_pickle=True
+        (pathlib.Path(db["fast-disk"]) / "suite2p" / "plane0" / "Fneu.npy").as_posix(),
+        allow_pickle=True,
     )
     Fc = F - segmentation_ops["neucoeff"] * Fneu
 
@@ -227,6 +232,8 @@ def deconvolution_suite2p(segmentation_ops: dict, db: dict) -> np.ndarray:
         tau=segmentation_ops["tau"],
         fs=segmentation_ops["fs"],
     )
-    np.save(os.path.join(segmentation_ops["save_path"], "spks.npy"), spikes)
+    np.save(
+        (pathlib.Path(segmentation_ops["save_path"]) / "spks.npy").as_posix(), spikes
+    )
 
     return spikes


### PR DESCRIPTION
## Summary
This PR standardizes file path handling across the codebase by converting `pathlib.Path` objects to POSIX-formatted strings when passing them to external libraries and system functions. This ensures cross-platform compatibility and prevents potential issues with libraries that don't natively support `Path` objects.

## Key Changes

- **caiman_loader.py**: Convert `Path` objects to POSIX strings for `h5py.File()`, `load_CNMF()`, and `os.stat()` calls
- **dandi.py**: Replace `os.path.join()` with `pathlib.Path` operations and convert to POSIX strings; change `os.curdir` to `"."` for consistency
- **prairie_view_loader.py**: 
  - Convert `Path` objects to POSIX strings for `ET.parse()` and `tifffile` operations
  - Fix dtype in array initialization from `int` to `np.uint16` to prevent unnecessary memory inflation of 16-bit TIFF files
- **run_caiman.py**: Convert output directory path to POSIX string for environment variable assignment
- **suite2p_trigger.py**: Replace string concatenation with `pathlib.Path` operations and convert to POSIX strings for `np.load()` and `np.save()` calls

## Implementation Details

- All changes use the `.as_posix()` method to convert `Path` objects to forward-slash-separated strings, ensuring compatibility across Windows, macOS, and Linux
- The changes maintain backward compatibility while improving code consistency and readability
- Bug fix in `prairie_view_loader.py`: Changed dtype from platform-dependent `int` to explicit `np.uint16` to prevent 2-4x memory inflation when writing 16-bit TIFF files

https://claude.ai/code/session_01Gc8cvRymM4vQuJetz1rnqk