### PR TITLE
Fix CaImAn loader bugs and add EXTRACT sparse array support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.8.0] - 2026-03-02
+
++ Fix - `caiman_loader.py` tuple unpacking bug in `extract_pw_rigid_mc` where
+  `nonrigid_correction` and `nonrigid_blocks` were not initialized as separate dicts
++ Fix - `caiman_loader.py` handle missing spike data (`estimates.S is None`) in mask
+  extraction when spike deconvolution is not run
++ Add - `extract_loader.py` support for reconstructed ndsparse format in v7.3 MAT files
+  with sparse spatial weights
++ Update - `extract_loader.py` handle both sparse and dense arrays in `load_results`
+
 ## [0.7.1] - 2025-08-05
 
 + Feature - Explicit `n_processes` arg in `run_caiman` to specify number of cores
@@ -98,6 +108,8 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 + Add - Readers for: `ScanImage`, `Suite2p`, `CaImAn`.
 
 
+[0.8.0]: https://github.com/datajoint/element-interface/releases/tag/0.8.0
+[0.7.1]: https://github.com/datajoint/element-interface/releases/tag/0.7.1
 [0.7.0]: https://github.com/datajoint/element-interface/releases/tag/0.7.0
 [0.6.0]: https://github.com/datajoint/element-interface/releases/tag/0.6.0
 [0.5.4]: https://github.com/datajoint/element-interface/releases/tag/0.5.4

--- a/element_interface/caiman_loader.py
+++ b/element_interface/caiman_loader.py
@@ -169,7 +169,7 @@ class CaImAn:
 
     def extract_pw_rigid_mc(self):
         # -- piece-wise rigid motion correction --
-        nonrigid_correction, nonrigid_blocks = {}
+        nonrigid_correction, nonrigid_blocks = {}, {}
         for pln_idx, (plane, pln_cm) in enumerate(self.planes.items()):
             block_count = len(nonrigid_blocks)
             if pln_idx == 0:

--- a/element_interface/caiman_loader.py
+++ b/element_interface/caiman_loader.py
@@ -458,22 +458,39 @@ class _CaImAn:
                 center_z = self.plane_idx
                 zpix = np.full(len(weights), center_z)
 
-            masks.append(
-                {
-                    "mask_id": comp_contour["neuron_id"],
-                    "mask_npix": len(weights),
-                    "mask_weights": weights,
-                    "mask_center_x": center_x,
-                    "mask_center_y": center_y,
-                    "mask_center_z": center_z,
-                    "mask_xpix": xpix,
-                    "mask_ypix": ypix,
-                    "mask_zpix": zpix,
-                    "inferred_trace": self.cnmf.estimates.C[comp_idx, :],
-                    "dff": self.cnmf.estimates.F_dff[comp_idx, :],
-                    "spikes": self.cnmf.estimates.S[comp_idx, :],
-                }
-            )
+            if self.cnmf.estimates.F_dff is not None and self.cnmf.estimates.F_dff is not None and self.cnmf.estimates.S is not None:
+                masks.append(
+                    {
+                        "mask_id": comp_contour["neuron_id"],
+                        "mask_npix": len(weights),
+                        "mask_weights": weights,
+                        "mask_center_x": center_x,
+                        "mask_center_y": center_y,
+                        "mask_center_z": center_z,
+                        "mask_xpix": xpix,
+                        "mask_ypix": ypix,
+                        "mask_zpix": zpix,
+                        "inferred_trace": self.cnmf.estimates.C[comp_idx, :],
+                        "dff": self.cnmf.estimates.F_dff[comp_idx, :],
+                        "spikes": self.cnmf.estimates.S[comp_idx, :],
+                    }
+                )
+            elif self.cnmf.estimates.S is None:
+                masks.append(
+                    {
+                        "mask_id": comp_contour["neuron_id"],
+                        "mask_npix": len(weights),
+                        "mask_weights": weights,
+                        "mask_center_x": center_x,
+                        "mask_center_y": center_y,
+                        "mask_center_z": center_z,
+                        "mask_xpix": xpix,
+                        "mask_ypix": ypix,
+                        "mask_zpix": zpix,
+                        "inferred_trace": self.cnmf.estimates.C[comp_idx, :],
+                        "dff": self.cnmf.estimates.F_dff[comp_idx, :],
+                    }
+                )
         return masks
 
 

--- a/element_interface/caiman_loader.py
+++ b/element_interface/caiman_loader.py
@@ -403,8 +403,12 @@ class _CaImAn:
         self._masks = None
 
         # ---- Metainfo ----
-        self.creation_time = datetime.fromtimestamp(os.stat(self.caiman_fp.as_posix()).st_ctime)
-        self.curation_time = datetime.fromtimestamp(os.stat(self.caiman_fp.as_posix()).st_ctime)
+        self.creation_time = datetime.fromtimestamp(
+            os.stat(self.caiman_fp.as_posix()).st_ctime
+        )
+        self.curation_time = datetime.fromtimestamp(
+            os.stat(self.caiman_fp.as_posix()).st_ctime
+        )
 
     @property
     def motion_correction(self):
@@ -458,7 +462,11 @@ class _CaImAn:
                 center_z = self.plane_idx
                 zpix = np.full(len(weights), center_z)
 
-            if self.cnmf.estimates.F_dff is not None and self.cnmf.estimates.F_dff is not None and self.cnmf.estimates.S is not None:
+            if (
+                self.cnmf.estimates.F_dff is not None
+                and self.cnmf.estimates.F_dff is not None
+                and self.cnmf.estimates.S is not None
+            ):
                 masks.append(
                     {
                         "mask_id": comp_contour["neuron_id"],
@@ -610,7 +618,7 @@ def _save_mc(
                         y + mc.overlaps[1] + mc.strides[1],
                     ]
                 )
-        
+
         h5g.require_dataset(
             "x_shifts_els",
             shape=np.shape(mc.x_shifts_els),
@@ -649,12 +657,12 @@ def _save_mc(
             data=mc.shifts_rig,
             dtype=mc.shifts_rig[0][0].dtype,
         )
-        
+
         # Not needed for global single rigid shift - there is no grid!!!
         # h5g.require_dataset(
         #    "coord_shifts_rig", shape=np.shape(grid), data=grid, dtype=type(grid[0][0])
         # )
-        
+
         reference_image = (
             np.tile(mc.total_template_rig, (1, 1, dims[-1]))
             if is3D

--- a/element_interface/extract_loader.py
+++ b/element_interface/extract_loader.py
@@ -2,49 +2,92 @@ import os
 import h5py
 from datetime import datetime
 from pathlib import Path
-
 import numpy as np
 from scipy.io import loadmat
+from scipy.sparse import csc_matrix
 
 
 class EXTRACT_loader:
     def __init__(self, extract_file_path: str):
         """Initialize EXTRACT loader class
-
         Args:
             extract_file_path (str): string, absolute file path to EXTRACT output file.
         """
-
         self.creation_time = datetime.fromtimestamp(os.stat(extract_file_path).st_ctime)
+        
         try:
             results = loadmat(extract_file_path)
-
-            self.S = results["output"][0]["spatial_weights"][
-                0
-            ]  # (Height, Width, MaskId)
-            self.spatial_weights = self.S.transpose([2, 0, 1])  # MaskId, Height, Width
-            self.T = results["output"][0]["temporal_weights"][0]  # (Time, MaskId)
-
+            self.S = results["output"][0]["spatial_weights"][0]
+            self.spatial_weights = self.S.transpose([2, 0, 1])
+            self.T = results["output"][0]["temporal_weights"][0]
         except NotImplementedError:
-
+            # v7.3 mat file - use h5py
             results = h5py.File(extract_file_path, "r")
-            self.spatial_weights = results["output"]["spatial_weights"][
-                :
-            ]  # (MaskId, Height, Width)
-            self.T = results["output"]["temporal_weights"][:]  # (MaskId, Time)
-
+            
+            spatial_weights_grp = results["output"]["spatial_weights"]
+            
+            # Check if this is our converted ndsparse format
+            if "type" in spatial_weights_grp and "sparse_2d" in spatial_weights_grp:
+                # Converted ndsparse format
+                self.spatial_weights = self._load_converted_ndsparse(spatial_weights_grp)
+            else:
+                # Original format
+                self.spatial_weights = spatial_weights_grp[:]
+            
+            self.T = results["output"]["temporal_weights"][:]
+    
+    def _load_converted_ndsparse(self, grp):
+        """Load spatial weights from converted ndsparse struct.
+        
+        Args:
+            grp: h5py group containing 'type', 'nd_shape', and 'sparse_2d'
+            
+        Returns:
+            scipy.sparse.csc_matrix in (n_cells, height, width) arrangement,
+            or reconstructed as list of 2D sparse arrays per cell
+        """
+        # Read the shape - stored as column vector, so flatten
+        nd_shape = grp["nd_shape"][:].flatten().astype(int)
+        height, width, n_cells = nd_shape
+        
+        # Load the 2D sparse matrix from HDF5
+        # MATLAB sparse is stored as: data, ir (row indices), jc (column pointers)
+        sparse_grp = grp["sparse_2d"]
+        data = sparse_grp["data"][:]
+        ir = sparse_grp["ir"][:].astype(int)  # Row indices (0-indexed in HDF5)
+        jc = sparse_grp["jc"][:].astype(int)  # Column pointers
+        
+        # Reconstruct as scipy CSC sparse matrix
+        # Shape is (height*width, n_cells)
+        sparse_2d = csc_matrix((data, ir, jc), shape=(height * width, n_cells))
+        
+        # Convert to (n_cells, height, width) format
+        # Each column becomes a 2D image for one cell
+        # Store as list of sparse 2D arrays for memory efficiency
+        spatial_weights = []
+        for i in range(n_cells):
+            col = sparse_2d.getcol(i).toarray().flatten()
+            # Reshape to 2D - MATLAB uses column-major (Fortran) order
+            cell_mask = col.reshape((height, width), order='F')
+            spatial_weights.append(csc_matrix(cell_mask))
+        
+        return spatial_weights
+    
     def load_results(self):
         """Load the EXTRACT results
-
         Returns:
             masks (dict): Details of the masks identified with the EXTRACT segmentation package.
         """
-        from scipy.sparse import find
-
+        from scipy.sparse import find, issparse
+        
         masks = []
-
         for mask_id, s in enumerate(self.spatial_weights):
-            ypixels, xpixels, weights = find(s)
+            # Handle both sparse and dense arrays
+            if issparse(s):
+                ypixels, xpixels, weights = find(s)
+            else:
+                ypixels, xpixels, weights = find(csc_matrix(s))
+            
             masks.append(
                 dict(
                     mask_id=mask_id,

--- a/element_interface/extract_loader.py
+++ b/element_interface/extract_loader.py
@@ -14,7 +14,7 @@ class EXTRACT_loader:
             extract_file_path (str): string, absolute file path to EXTRACT output file.
         """
         self.creation_time = datetime.fromtimestamp(os.stat(extract_file_path).st_ctime)
-        
+
         try:
             results = loadmat(extract_file_path)
             self.S = results["output"][0]["spatial_weights"][0]
@@ -23,25 +23,27 @@ class EXTRACT_loader:
         except NotImplementedError:
             # v7.3 mat file - use h5py
             results = h5py.File(extract_file_path, "r")
-            
+
             spatial_weights_grp = results["output"]["spatial_weights"]
-            
+
             # Check if this is our converted ndsparse format
             if "type" in spatial_weights_grp and "sparse_2d" in spatial_weights_grp:
                 # Converted ndsparse format
-                self.spatial_weights = self._load_converted_ndsparse(spatial_weights_grp)
+                self.spatial_weights = self._load_converted_ndsparse(
+                    spatial_weights_grp
+                )
             else:
                 # Original format
                 self.spatial_weights = spatial_weights_grp[:]
-            
+
             self.T = results["output"]["temporal_weights"][:]
-    
+
     def _load_converted_ndsparse(self, grp):
         """Load spatial weights from converted ndsparse struct.
-        
+
         Args:
             grp: h5py group containing 'type', 'nd_shape', and 'sparse_2d'
-            
+
         Returns:
             scipy.sparse.csc_matrix in (n_cells, height, width) arrangement,
             or reconstructed as list of 2D sparse arrays per cell
@@ -49,18 +51,18 @@ class EXTRACT_loader:
         # Read the shape - stored as column vector, so flatten
         nd_shape = grp["nd_shape"][:].flatten().astype(int)
         height, width, n_cells = nd_shape
-        
+
         # Load the 2D sparse matrix from HDF5
         # MATLAB sparse is stored as: data, ir (row indices), jc (column pointers)
         sparse_grp = grp["sparse_2d"]
         data = sparse_grp["data"][:]
         ir = sparse_grp["ir"][:].astype(int)  # Row indices (0-indexed in HDF5)
         jc = sparse_grp["jc"][:].astype(int)  # Column pointers
-        
+
         # Reconstruct as scipy CSC sparse matrix
         # Shape is (height*width, n_cells)
         sparse_2d = csc_matrix((data, ir, jc), shape=(height * width, n_cells))
-        
+
         # Convert to (n_cells, height, width) format
         # Each column becomes a 2D image for one cell
         # Store as list of sparse 2D arrays for memory efficiency
@@ -68,18 +70,18 @@ class EXTRACT_loader:
         for i in range(n_cells):
             col = sparse_2d.getcol(i).toarray().flatten()
             # Reshape to 2D - MATLAB uses column-major (Fortran) order
-            cell_mask = col.reshape((height, width), order='F')
+            cell_mask = col.reshape((height, width), order="F")
             spatial_weights.append(csc_matrix(cell_mask))
-        
+
         return spatial_weights
-    
+
     def load_results(self):
         """Load the EXTRACT results
         Returns:
             masks (dict): Details of the masks identified with the EXTRACT segmentation package.
         """
         from scipy.sparse import find, issparse
-        
+
         masks = []
         for mask_id, s in enumerate(self.spatial_weights):
             # Handle both sparse and dense arrays
@@ -87,7 +89,7 @@ class EXTRACT_loader:
                 ypixels, xpixels, weights = find(s)
             else:
                 ypixels, xpixels, weights = find(csc_matrix(s))
-            
+
             masks.append(
                 dict(
                     mask_id=mask_id,

--- a/element_interface/version.py
+++ b/element_interface/version.py
@@ -1,3 +1,3 @@
 """Package metadata"""
 
-__version__ = "0.7.1"
+__version__ = "0.8.0"


### PR DESCRIPTION
## Summary
- **Fix `extract_pw_rigid_mc` tuple unpacking bug**: `nonrigid_correction, nonrigid_blocks = {}` was only initializing one dict — now correctly initializes both as separate empty dicts
- **Handle missing spike data in CaImAn mask extraction**: When `estimates.S` is `None` (spike deconvolution not run), mask extraction now gracefully omits the `spikes` key instead of raising an error
- **Add ndsparse support in EXTRACT_loader**: New `_load_converted_ndsparse` method reconstructs sparse spatial weights from v7.3 MAT files that store data in MATLAB's ndsparse format (CSC sparse matrix with `data`, `ir`, `jc` arrays)
- **Handle both sparse and dense arrays in EXTRACT `load_results`**: Uses `scipy.sparse.issparse` to correctly process either format
- **Apply Black formatting** to both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)