### PR TITLE
fix: Handle missing CaImAn estimates (C, F_dff, S) in extract_masks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+[0.8.1] - 2026-03-03
+
++ Fix - `caiman_loader.py` replace branching if/elif with inline None guards for each estimate field.
+
 ## [0.8.0] - 2026-03-02
 
 + Fix - `caiman_loader.py` tuple unpacking bug in `extract_pw_rigid_mc` where
@@ -108,6 +112,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 + Add - Readers for: `ScanImage`, `Suite2p`, `CaImAn`.
 
 
+[0.8.1]: https://github.com/datajoint/element-interface/releases/tag/0.8.1
 [0.8.0]: https://github.com/datajoint/element-interface/releases/tag/0.8.0
 [0.7.1]: https://github.com/datajoint/element-interface/releases/tag/0.7.1
 [0.7.0]: https://github.com/datajoint/element-interface/releases/tag/0.7.0

--- a/element_interface/caiman_loader.py
+++ b/element_interface/caiman_loader.py
@@ -473,15 +473,21 @@ class _CaImAn:
                     "mask_xpix": xpix,
                     "mask_ypix": ypix,
                     "mask_zpix": zpix,
-                    "inferred_trace": self.cnmf.estimates.C[comp_idx, :]
-                    if self.cnmf.estimates.C is not None
-                    else None,
-                    "dff": self.cnmf.estimates.F_dff[comp_idx, :]
-                    if self.cnmf.estimates.F_dff is not None
-                    else None,
-                    "spikes": self.cnmf.estimates.S[comp_idx, :]
-                    if self.cnmf.estimates.S is not None
-                    else None,
+                    "inferred_trace": (
+                        self.cnmf.estimates.C[comp_idx, :]
+                        if self.cnmf.estimates.C is not None
+                        else None
+                    ),
+                    "dff": (
+                        self.cnmf.estimates.F_dff[comp_idx, :]
+                        if self.cnmf.estimates.F_dff is not None
+                        else None
+                    ),
+                    "spikes": (
+                        self.cnmf.estimates.S[comp_idx, :]
+                        if self.cnmf.estimates.S is not None
+                        else None
+                    ),
                 }
             )
         return masks

--- a/element_interface/caiman_loader.py
+++ b/element_interface/caiman_loader.py
@@ -462,43 +462,28 @@ class _CaImAn:
                 center_z = self.plane_idx
                 zpix = np.full(len(weights), center_z)
 
-            if (
-                self.cnmf.estimates.F_dff is not None
-                and self.cnmf.estimates.F_dff is not None
-                and self.cnmf.estimates.S is not None
-            ):
-                masks.append(
-                    {
-                        "mask_id": comp_contour["neuron_id"],
-                        "mask_npix": len(weights),
-                        "mask_weights": weights,
-                        "mask_center_x": center_x,
-                        "mask_center_y": center_y,
-                        "mask_center_z": center_z,
-                        "mask_xpix": xpix,
-                        "mask_ypix": ypix,
-                        "mask_zpix": zpix,
-                        "inferred_trace": self.cnmf.estimates.C[comp_idx, :],
-                        "dff": self.cnmf.estimates.F_dff[comp_idx, :],
-                        "spikes": self.cnmf.estimates.S[comp_idx, :],
-                    }
-                )
-            elif self.cnmf.estimates.S is None:
-                masks.append(
-                    {
-                        "mask_id": comp_contour["neuron_id"],
-                        "mask_npix": len(weights),
-                        "mask_weights": weights,
-                        "mask_center_x": center_x,
-                        "mask_center_y": center_y,
-                        "mask_center_z": center_z,
-                        "mask_xpix": xpix,
-                        "mask_ypix": ypix,
-                        "mask_zpix": zpix,
-                        "inferred_trace": self.cnmf.estimates.C[comp_idx, :],
-                        "dff": self.cnmf.estimates.F_dff[comp_idx, :],
-                    }
-                )
+            masks.append(
+                {
+                    "mask_id": comp_contour["neuron_id"],
+                    "mask_npix": len(weights),
+                    "mask_weights": weights,
+                    "mask_center_x": center_x,
+                    "mask_center_y": center_y,
+                    "mask_center_z": center_z,
+                    "mask_xpix": xpix,
+                    "mask_ypix": ypix,
+                    "mask_zpix": zpix,
+                    "inferred_trace": self.cnmf.estimates.C[comp_idx, :]
+                    if self.cnmf.estimates.C is not None
+                    else None,
+                    "dff": self.cnmf.estimates.F_dff[comp_idx, :]
+                    if self.cnmf.estimates.F_dff is not None
+                    else None,
+                    "spikes": self.cnmf.estimates.S[comp_idx, :]
+                    if self.cnmf.estimates.S is not None
+                    else None,
+                }
+            )
         return masks
 
 

--- a/element_interface/version.py
+++ b/element_interface/version.py
@@ -1,3 +1,3 @@
 """Package metadata"""
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"


### PR DESCRIPTION
Replace branching if/elif with inline None guards for each estimate field. Prevents silent mask drops when any combination of estimates is missing, and fixes duplicate F_dff check.