### PR TITLE
Fix plane-to-file mapping for bidirectional Z scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.8.2] - 2026-03-10
+
++ Fix - `prairie_view_loader.py` correct plane-to-file mapping for bidirectional Z scans.
+  With `bidirectionalZ="True"`, Frame[@index] alternates meaning between forward and
+  backward cycles, causing planes 1 and 3 to receive mixed data from two physical depths.
+  Now groups files by z-position using per-cycle index mapping.
++ Fix - `prairie_view_loader.py` extract `fieldZ` from cycle 1 (forward) instead of
+  cycle 2 so z-positions align with `plane_indices` ordering for bidirectional Z scans.
++ Add - `NotImplementedError` guard for multipage TIFF + bidirectional Z combination.
++ Fix - `prairie_view_loader.py` normalize `z_fields` to float in all code paths
+  (single-controller path previously returned strings).
+
 [0.8.1] - 2026-03-03
 
 + Fix - `caiman_loader.py` replace branching if/elif with inline None guards for each estimate field.
@@ -112,6 +124,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 + Add - Readers for: `ScanImage`, `Suite2p`, `CaImAn`.
 
 
+[0.8.2]: https://github.com/datajoint/element-interface/releases/tag/0.8.2
 [0.8.1]: https://github.com/datajoint/element-interface/releases/tag/0.8.1
 [0.8.0]: https://github.com/datajoint/element-interface/releases/tag/0.8.0
 [0.7.1]: https://github.com/datajoint/element-interface/releases/tag/0.7.1

--- a/element_interface/prairie_view_loader.py
+++ b/element_interface/prairie_view_loader.py
@@ -84,16 +84,33 @@ class PrairieViewMeta:
                 channel in self.meta["channels"]
             ), f"Invalid 'channel' - Channels: {self.meta['channels']}"
 
-        # single-plane ome.tif does not have "@index" under Frame to search for
-        plane_search = f"/[@index='{plane_idx}']" if self.meta["num_planes"] > 1 else ""
-        # ome.tif does have "@channel" under File regardless of single or multi channel
         channel_search = f"/[@channel='{channel}']"
 
-        frames = self._xml_root.findall(
-            f".//Sequence/Frame{plane_search}/File{channel_search}"
-        )
+        if self.meta.get("_bidi_z_index_map") and self.meta["num_planes"] > 1:
+            # Bidirectional Z: Frame[@index] alternates meaning between
+            # forward (odd) and backward (even) cycles.  Use the stored
+            # z-position mapping to pick the correct index per direction.
+            bidi_map = self.meta["_bidi_z_index_map"]
+            fwd_idx = plane_idx
+            bwd_idx = bidi_map[plane_idx]
 
-        fnames = np.unique([f.attrib["filename"] for f in frames]).tolist()
+            fnames = []
+            for seq in self._xml_root.findall(".//Sequence[@cycle]"):
+                cycle_num = int(seq.attrib.get("cycle"))
+                target_idx = fwd_idx if cycle_num % 2 == 1 else bwd_idx
+                for frame in seq.findall(f"Frame[@index='{target_idx}']"):
+                    for f in frame.findall(f"File{channel_search}"):
+                        fnames.append(f.attrib["filename"])
+            fnames = np.unique(fnames).tolist()
+        else:
+            # Unidirectional Z or single plane: Frame[@index] is stable
+            plane_search = (
+                f"/[@index='{plane_idx}']" if self.meta["num_planes"] > 1 else ""
+            )
+            frames = self._xml_root.findall(
+                f".//Sequence/Frame{plane_search}/File{channel_search}"
+            )
+            fnames = np.unique([f.attrib["filename"] for f in frames]).tolist()
         return fnames if not return_pln_chn else (fnames, plane_idx, channel)
 
     def write_single_bigtiff(
@@ -127,6 +144,13 @@ class PrairieViewMeta:
 
         output_tiff_list = []
         if self.meta["is_multipage"]:
+            if self.meta.get("bidirectional_z"):
+                raise NotImplementedError(
+                    "Multipage TIFF extraction with bidirectional Z scanning is not "
+                    "yet supported. The page interleaving formula assumes "
+                    "unidirectional Z order. Use single-page TIFF output from "
+                    "PrairieView for bidirectional Z scans."
+                )
             if gb_per_file is not None:
                 logger.warning(
                     "Ignoring `gb_per_file` argument for multi-page tiff (NotYetImplemented)"
@@ -237,6 +261,7 @@ def _extract_prairieview_metadata(xml_filepath: str):
     xml_root = xml_tree.getroot()
 
     bidirectional_scan = False  # Does not support bidirectional
+    bidi_z_index_map = None
     roi = 0
     is_multipage = xml_root.find(".//Sequence/Frame/File/[@page]") is not None
     recording_start_time = xml_root.find(".//Sequence/[@cycle='1']").attrib.get("time")
@@ -326,23 +351,29 @@ def _extract_prairieview_metadata(xml_filepath: str):
         plane_indices = set(planes)
         n_depths = len(plane_indices)
 
+        # --- Determine which z-controller is actively changing depth ---
         z_controllers = xml_root.findall(
-            ".//Sequence/[@cycle='2']/Frame/[@index='1']/PVStateShard/PVStateValue/[@key='positionCurrent']/SubindexedValues/[@index='ZAxis']/SubindexedValue"
+            ".//Sequence/[@cycle='2']/Frame/[@index='1']/PVStateShard/PVStateValue"
+            "/[@key='positionCurrent']/SubindexedValues/[@index='ZAxis']/SubindexedValue"
         )
 
-        # If more than one Z-axis controllers are found,
-        # check which controller is changing z_field depth. Only 1 controller
-        # must change depths.
         if len(z_controllers) > 1:
+            # Multiple z-axis controllers — find the one whose values vary
+            # across frames (only one controller should be driving depth).
             z_repeats = []
+            controller_subindices = []
             for controller in xml_root.findall(
-                ".//Sequence/[@cycle='2']/Frame/[@index='1']/PVStateShard/PVStateValue/[@key='positionCurrent']/SubindexedValues/[@index='ZAxis']/"
+                ".//Sequence/[@cycle='2']/Frame/[@index='1']/PVStateShard/PVStateValue"
+                "/[@key='positionCurrent']/SubindexedValues/[@index='ZAxis']/"
             ):
+                controller_subindices.append(controller.attrib.get("subindex"))
                 z_repeats.append(
                     [
                         float(z.attrib.get("value"))
                         for z in xml_root.findall(
-                            ".//Sequence/[@cycle='2']/Frame/PVStateShard/PVStateValue/[@key='positionCurrent']/SubindexedValues/[@index='ZAxis']/SubindexedValue/[@subindex='{0}']".format(
+                            ".//Sequence/[@cycle='2']/Frame/PVStateShard/PVStateValue"
+                            "/[@key='positionCurrent']/SubindexedValues/[@index='ZAxis']"
+                            "/SubindexedValue/[@subindex='{0}']".format(
                                 controller.attrib.get("subindex")
                             )
                         )
@@ -356,15 +387,65 @@ def _extract_prairieview_metadata(xml_filepath: str):
                 sum(controller_assert) == 1
             ), "Multiple controllers changing z depth is not supported"
 
-            z_fields = z_repeats[controller_assert.index(True)]
-
+            active_z_idx = controller_assert.index(True)
+            active_subindex = controller_subindices[active_z_idx]
         else:
+            active_subindex = (
+                z_controllers[0].attrib.get("subindex") if z_controllers else "0"
+            )
+
+        # --- Extract z-positions per plane ---
+        _z_xpath = (
+            ".//Sequence/[@cycle='{cycle}']/Frame/PVStateShard/PVStateValue"
+            "/[@key='positionCurrent']/SubindexedValues/[@index='ZAxis']"
+            "/SubindexedValue/[@subindex='{subindex}']"
+        )
+
+        if bidirection_z:
+            # With bidirectional Z, even-numbered cycles scan planes in
+            # reverse z-order.  Extract z-positions from cycle 1 (forward)
+            # so that fieldZ aligns with the plane_indices ordering.
             z_fields = [
-                z.attrib.get("value")
+                float(z.attrib.get("value"))
                 for z in xml_root.findall(
-                    ".//Sequence/[@cycle='2']/Frame/PVStateShard/PVStateValue/[@key='positionCurrent']/SubindexedValues/[@index='ZAxis']/SubindexedValue/[@subindex='0']"
+                    _z_xpath.format(cycle="1", subindex=active_subindex)
                 )
             ]
+
+            # Build mapping: plane_idx → Frame[@index] in backward (even) cycles.
+            # In forward cycles, Frame[@index] matches the plane ordering from
+            # cycle 1 directly.  In backward cycles the z-positions are reversed,
+            # so a different index is needed to reach the same physical plane.
+            z_fields_bwd = [
+                float(z.attrib.get("value"))
+                for z in xml_root.findall(
+                    _z_xpath.format(cycle="2", subindex=active_subindex)
+                )
+            ]
+
+            fwd_indices = sorted(plane_indices)
+            fwd_z = dict(zip(fwd_indices, z_fields))
+            bwd_z = dict(zip(fwd_indices, z_fields_bwd))
+
+            bidi_z_index_map = {}
+            for fi, fz in fwd_z.items():
+                for bi, bz in bwd_z.items():
+                    if abs(fz - bz) < 0.01:
+                        bidi_z_index_map[fi] = bi
+                        break
+                else:
+                    raise ValueError(
+                        f"No backward-cycle match for plane {fi} (z={fz}). "
+                        f"Backward z-values: {bwd_z}"
+                    )
+        else:
+            z_fields = [
+                float(z.attrib.get("value"))
+                for z in xml_root.findall(
+                    _z_xpath.format(cycle="2", subindex=active_subindex)
+                )
+            ]
+            bidi_z_index_map = None
 
         assert (
             len(z_fields) == n_depths
@@ -395,7 +476,8 @@ def _extract_prairieview_metadata(xml_filepath: str):
         fieldZ=z_fields,
         recording_time=recording_start_time,
         channels=list(channels),
-        plane_indices=list(plane_indices),
+        plane_indices=sorted(plane_indices),
+        _bidi_z_index_map=bidi_z_index_map if bidirection_z else None,
     )
 
     return metainfo

--- a/element_interface/version.py
+++ b/element_interface/version.py
@@ -1,3 +1,3 @@
 """Package metadata"""
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"


### PR DESCRIPTION
## Summary
- **Fix** `get_prairieview_filenames()` to return files from one physical z-depth per plane for bidirectional Z scans. Previously, `Frame[@index]` was treated as a stable plane identifier, but it alternates meaning between forward (1→2→3) and backward (3→2→1) cycles, causing planes 1 and 3 to receive a 50/50 mix of data from two different depths.
- **Fix** `fieldZ` extraction to use cycle 1 (forward) instead of cycle 2, so z-positions align with `plane_indices` ordering.
- **Fix** Normalize `z_fields` to `float` in the single-controller code path (previously returned strings).
- **Add** `NotImplementedError` guard for multipage TIFF + bidirectional Z combination (page interleaving formula assumes unidirectional order).

## Background: PrairieView XML structure for bidirectional Z

The core issue is that PrairieView's `Frame[@index]` is a **within-cycle sequence number** (order of acquisition), not a stable physical plane identifier. For a 3-plane bidirectional Z scan at z=100, 200, 300:

| | Frame index=1 | Frame index=2 | Frame index=3 |
|---|---|---|---|
| Cycle 1 (forward) | z=100 | z=200 | z=300 |
| Cycle 2 (backward) | z=300 | z=200 | z=100 |
| Cycle 3 (forward) | z=100 | z=200 | z=300 |
| Cycle 4 (backward) | z=300 | z=200 | z=100 |

The old code used a single XPath like `Frame[@index='1']` across **all** cycles, so plane 1 got z=100 from odd cycles and z=300 from even cycles — a 50/50 mix of two depths.

## Section 1: Z-Controller Refactor

The goal here is to figure out **which z-axis controller is actively driving depth changes**, since PrairieView systems can have multiple z-controllers (e.g., a piezo + a motorized stage), but only one is used for the z-stack.

### Original code:

```python
z_controllers = xml_root.findall(
    ".../[@cycle='2']/Frame/[@index='1']/.../SubindexedValue"
)

if len(z_controllers) > 1:
    # ... find which controller varies, extract z_fields directly
    z_fields = z_repeats[controller_assert.index(True)]
else:
    z_fields = [
        z.attrib.get("value")  # BUG: returns strings
        for z in xml_root.findall(
            "...[@cycle='2']...[@subindex='0']"  # hardcoded subindex='0'
        )
    ]
```

Problems:
1. Multi-controller path extracted `z_fields` right there; single-controller path did it separately with a hardcoded `subindex='0'`
2. Single-controller path returned **strings** (no `float()` wrapper)
3. Both paths pulled from **cycle 2** (backward) — wrong for bidi-Z

### New code:

```python
if len(z_controllers) > 1:
    # Same logic to find which controller varies...
    active_z_idx = controller_assert.index(True)
    active_subindex = controller_subindices[active_z_idx]  # e.g. "1"
else:
    active_subindex = (
        z_controllers[0].attrib.get("subindex") if z_controllers else "0"
    )
```

Now **both paths just determine `active_subindex`** — a single string like `"0"` or `"1"`. The actual z-field extraction is deferred to a unified block below. This eliminates the string-vs-float inconsistency and the hardcoded `subindex='0'`.

## Section 2: Building `_bidi_z_index_map`

This is the core of the fix. A reusable XPath template is defined once:

```python
_z_xpath = (
    ".//Sequence/[@cycle='{cycle}']/Frame/PVStateShard/PVStateValue"
    "/[@key='positionCurrent']/SubindexedValues/[@index='ZAxis']"
    "/SubindexedValue/[@subindex='{subindex}']"
)
```

### For bidirectional Z (`bidirection_z == True`):

**Step 1** — Get z-positions from cycle 1 (forward):
```python
z_fields = [float(z.attrib.get("value"))
            for z in xml_root.findall(_z_xpath.format(cycle="1", subindex=active_subindex))]
# Result: [100.0, 200.0, 300.0]  (one per Frame in cycle 1)
```

This is the fix for the `fieldZ` alignment — cycle 1 is forward, so z-values match the `plane_indices` ordering `[1, 2, 3]`.

**Step 2** — Get z-positions from cycle 2 (backward):
```python
z_fields_bwd = [float(z.attrib.get("value"))
                for z in xml_root.findall(_z_xpath.format(cycle="2", subindex=active_subindex))]
# Result: [300.0, 200.0, 100.0]  (reversed — first acquired frame is deepest)
```

**Step 3** — Pair indices with z-values:
```python
fwd_indices = sorted(plane_indices)          # [1, 2, 3]
fwd_z = dict(zip(fwd_indices, z_fields))      # {1: 100.0, 2: 200.0, 3: 300.0}
bwd_z = dict(zip(fwd_indices, z_fields_bwd))  # {1: 300.0, 2: 200.0, 3: 100.0}
```

Here `bwd_z` means: "in cycle 2, `Frame[@index='1']` is at z=300, `Frame[@index='2']` is at z=200, `Frame[@index='3']` is at z=100."

**Step 4** — Match forward plane indices to backward plane indices by z-position:
```python
bidi_z_index_map = {}
for fi, fz in fwd_z.items():        # fi=1,fz=100 | fi=2,fz=200 | fi=3,fz=300
    for bi, bz in bwd_z.items():     # search backward for matching z
        if abs(fz - bz) < 0.01:
            bidi_z_index_map[fi] = bi
            break
```

Walking through each iteration:
- `fi=1, fz=100.0`: Scans backward dict — `bi=3, bz=100.0` matches. → `{1: 3}`
- `fi=2, fz=200.0`: Scans backward dict — `bi=2, bz=200.0` matches. → `{1: 3, 2: 2}`
- `fi=3, fz=300.0`: Scans backward dict — `bi=1, bz=300.0` matches. → `{1: 3, 2: 2, 3: 1}`

**Result**: `_bidi_z_index_map = {1: 3, 2: 2, 3: 1}`

Meaning: "To get the same physical z-position as forward-plane-1 during a backward cycle, use `Frame[@index='3']`."

### For unidirectional Z (`bidirection_z == False`):

```python
z_fields = [float(z.attrib.get("value"))
            for z in xml_root.findall(_z_xpath.format(cycle="2", subindex=active_subindex))]
bidi_z_index_map = None
```

Same as before but now with `float()` and uses the dynamically-determined `active_subindex` instead of hardcoded `'0'`.

## Section 3: `get_prairieview_filenames`

### When `_bidi_z_index_map` exists (bidi-Z, multi-plane):

```python
bidi_map = self.meta["_bidi_z_index_map"]   # {1: 3, 2: 2, 3: 1}
fwd_idx = plane_idx                          # e.g. 1
bwd_idx = bidi_map[plane_idx]               # e.g. 3
```

For `plane_idx=1`: forward index is 1, backward index is 3.

```python
fnames = []
for seq in self._xml_root.findall(".//Sequence[@cycle]"):
    cycle_num = int(seq.attrib.get("cycle"))
    target_idx = fwd_idx if cycle_num % 2 == 1 else bwd_idx
```

Iterates every `<Sequence>` element. For each cycle:
- Odd cycle (forward): use `target_idx = 1` → `Frame[@index='1']` → z=100
- Even cycle (backward): use `target_idx = 3` → `Frame[@index='3']` → z=100

Both pick z=100. Every file returned is from the same physical depth.

```python
    for frame in seq.findall(f"Frame[@index='{target_idx}']"):
        for f in frame.findall(f"File{channel_search}"):
            fnames.append(f.attrib["filename"])
fnames = np.unique(fnames).tolist()
```

Within each matched Frame, collects filenames for the requested channel, then deduplicates.

### When no bidi map (unidirectional or single-plane):

```python
plane_search = f"/[@index='{plane_idx}']" if self.meta["num_planes"] > 1 else ""
frames = self._xml_root.findall(
    f".//Sequence/Frame{plane_search}/File{channel_search}"
)
fnames = np.unique([f.attrib["filename"] for f in frames]).tolist()
```

This is the **original logic**, unchanged — a single XPath across all cycles. Safe here because `Frame[@index]` has consistent meaning when z-order doesn't reverse.

## Minor fixes

- **`NotImplementedError` for multipage TIFF + bidi-Z**: The multipage TIFF page interleaving formula assumes unidirectional z-ordering. Added a defensive guard.
- **`sorted(plane_indices)`**: Was `list(plane_indices)` from a `set`, which has non-deterministic ordering. Now explicitly sorted.
- **`float()` in all paths**: Both bidi and non-bidi paths now use `float(z.attrib.get("value"))`.

## Test plan
Tested with 14 regression tests in `fmi_luthi/tests/unit/test_prairie_view_loader.py` using the A_1040743 golden dataset (3-plane bidirectional-Z session, 7748 cycles):

- [x] `test_bidirectional_z_flag_detected` — `bidirectional_z` metadata is `True`
- [x] `test_plane_count` — `num_planes == 3`
- [x] `test_plane_indices_sorted` — `plane_indices == [1, 2, 3]`
- [x] `test_field_z_forward_order` — `fieldZ` in ascending order (cycle 1)
- [x] `test_bidi_z_index_map_exists` — mapping dict is present
- [x] `test_bidi_z_index_map_swaps_outer_planes` — planes 1↔3 swap, plane 2 maps to self
- [x] `test_frames_per_plane` — each plane gets exactly `num_frames` files
- [x] `test_all_files_same_z` (×3 planes) — every file for a plane has one unique z-position
- [x] `test_file_z_matches_field_z` (×3 planes) — file z-positions match `fieldZ` metadata
- [x] `test_single_plane_has_no_bidi_map` — single-plane scans unaffected (`_bidi_z_index_map is None`)

All 14 tests pass. Tests also verified to **fail** (8/14) against the unfixed code, confirming they correctly detect the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
